### PR TITLE
If the payload type is an octet-stream don't parse it as utf-8

### DIFF
--- a/coapthon/serializer.py
+++ b/coapthon/serializer.py
@@ -113,7 +113,10 @@ class Serializer(object):
                         raise AttributeError("Packet length %s, pos %s" % (length_packet, pos))
                     message.payload = ""
                     payload = values[pos:]
-                    message.payload = payload.decode("utf-8")
+                    if message.payload_type == defines.Content_types["application/octet-stream"]:
+                        message.payload = payload
+                    else:
+                        message.payload = payload.decode("utf-8")
                     pos += len(payload)
 
             return message


### PR DESCRIPTION
When receiving an octet-stream it would try and parse it as utf-8 which would give a UnicodeDecodeError.