### PR TITLE
Update Blocklayer to better deal with Block1 option

### DIFF
--- a/coapthon/layers/blocklayer.py
+++ b/coapthon/layers/blocklayer.py
@@ -141,10 +141,10 @@ class BlockLayer(object):
             item.num += 1
             item.byte += item.size
             if len(item.payload) <= item.byte:
-                m = 0
+                item.m = 0
             else:
-                m = 1
-            request.block1 = (item.num, m, item.size)
+                item.m = 1
+            request.block1 = (item.num, item.m, item.size)
         elif transaction.response.block2 is not None:
 
             num, m, size = transaction.response.block2


### PR DESCRIPTION
On the last block answer, the Client still sent another empty message, it didn't take into account the fact that the previous block was sent with m=0. This commit fixed that for me.