### PR TITLE
combined multicast and unicast sockets to one socket

### DIFF
--- a/coapthon/server/coap.py
+++ b/coapthon/server/coap.py
@@ -79,16 +79,11 @@ class CoAP(object):
             # Join group
             if addrinfo[0] == socket.AF_INET:  # IPv4
                 self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-
-                # Allow multiple copies of this program on one machine
-                # (not strictly needed)
                 self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                self._socket.bind((defines.ALL_COAP_NODES, self.server_address[1]))
+                self._socket.bind(('', self.server_address[1]))
                 mreq = struct.pack("4sl", socket.inet_aton(defines.ALL_COAP_NODES), socket.INADDR_ANY)
                 self._socket.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
-                self._unicast_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                self._unicast_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                self._unicast_socket.bind(self.server_address)
+<<<<<<< HEAD
             else:
                 self._socket = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
 
@@ -104,7 +99,8 @@ class CoAP(object):
                 self._unicast_socket = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
                 self._unicast_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 self._unicast_socket.bind(self.server_address)
-
+=======
+>>>>>>> 07164880d988b318b95d9625bac8786b8ee7b7e8
         else:
             if addrinfo[0] == socket.AF_INET:  # IPv4
                 self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -252,10 +248,7 @@ class CoAP(object):
             logger.debug("send_datagram - " + str(message))
             serializer = Serializer()
             message = serializer.serialize(message)
-            if self.multicast:
-                self._unicast_socket.sendto(message, (host, port))
-            else:
-                self._socket.sendto(message, (host, port))
+            self._socket.sendto(message, (host, port))
 
     def add_resource(self, path, resource):
         """


### PR DESCRIPTION
Hi,
I am encountering a problem when using a multicast server which should be requested with a unicast request. In the example below, I only get the first response after the multicast but not the second response from the unicast request. I am not sure, if my solution attempt is correct, but maybe you could have a look. Thanks!

To reproduce on localhost:

I first started the server.
```python
from coapthon.server.coap import CoAP

from coapthon.resources.resource import Resource

class BasicResource(Resource):
    def __init__(self, name="BasicResource", coap_server=None):
        super(BasicResource, self).__init__(name, coap_server, visible=True,
                                            observable=True, allow_children=True)
        self.payload = "Basic Resource"

    def render_GET(self, request):
        return self

    def render_PUT(self, request):
        self.payload = request.payload
        return self

    def render_POST(self, request):
        res = BasicResource()
        res.location_query = request.uri_query
        res.payload = request.payload
        return res

    def render_DELETE(self, request):
        return True
        
class CoAPServer(CoAP):
    def __init__(self, host, port):
        CoAP.__init__(self, (host, port), multicast=True)
        self.add_resource('basic/', BasicResource())

def main():
    server = CoAPServer("0.0.0.0", 5683)
    try:
        server.listen(10)
    except KeyboardInterrupt:
        server.close()

if __name__ == '__main__':
    main()
```

Then I started the client which discovers the server with a multicast request and then sends a unicast request with the informations from the first response.
```python
from coapthon.client.helperclient import HelperClient

# Multicast 
host = "224.0.1.187"
port = 5683
path = "basic"

client = HelperClient(server=(host, port))
response = client.get(path)
print(response.pretty_print())

# Unicast
host = response.source[0]
port = response.source[1]

client = HelperClient(server=(host, port))
response = client.get(path)
print(response.pretty_print())
```