### PR TITLE
added possibility to define own .well-known-core endpoint

### DIFF
--- a/coapthon/layers/forwardLayer.py
+++ b/coapthon/layers/forwardLayer.py
@@ -50,11 +50,12 @@ class ForwardLayer(object):
         :rtype : Transaction
         :return: the edited transaction
         """
+        wkc_resource_is_defined = defines.DISCOVERY_URL in self._server.root
         path = str("/" + transaction.request.uri_path)
         transaction.response = Response()
         transaction.response.destination = transaction.request.source
         transaction.response.token = transaction.request.token
-        if path == defines.DISCOVERY_URL:
+        if path == defines.DISCOVERY_URL and not wkc_resource_is_defined:
             transaction = self._server.resourceLayer.discover(transaction)
         else:
             new = False

--- a/coapthon/layers/requestlayer.py
+++ b/coapthon/layers/requestlayer.py
@@ -52,11 +52,12 @@ class RequestLayer(object):
         :rtype : Transaction
         :return: the edited transaction with the response to the request
         """
+        wkc_resource_is_defined = defines.DISCOVERY_URL in self._server.root
         path = str("/" + transaction.request.uri_path)
         transaction.response = Response()
         transaction.response.destination = transaction.request.source
         transaction.response.token = transaction.request.token
-        if path == defines.DISCOVERY_URL:
+        if path == defines.DISCOVERY_URL and not wkc_resource_is_defined:
             transaction = self._server.resourceLayer.discover(transaction)
         else:
             try:

--- a/coapthon/utils.py
+++ b/coapthon/utils.py
@@ -186,3 +186,6 @@ class Tree(object):
 
     def __delitem__(self, key):
         del self.tree[key]
+
+    def __contains__(self, item):
+        return item in self.tree


### PR DESCRIPTION
This PR adds the possibilty to create an own .well-known/core endpoint. If it is not created by the user, the auto generated endpoint will be used. This closes #13 