### PR TITLE
Fix payload transmitted in Block2 transfer

### DIFF
--- a/coapthon/layers/blocklayer.py
+++ b/coapthon/layers/blocklayer.py
@@ -58,7 +58,7 @@ class BlockLayer(object):
                 del transaction.request.block2
             else:
                 # early negotiation
-                byte = 0
+                byte = num * size
                 self._block2_receive[key_token] = BlockItem(byte, num, m, size)
                 del transaction.request.block2
 


### PR DESCRIPTION
Previosly the CoAP server transmitted the first block of data for Block2
transfer, even when a client requested in a Block2 request any other
block. This patch changes server operation to transmit the payload
block requested by the client.

Signed-off-by: Hubert Miś <hubert.mis@gmail.com>