### PR TITLE
uses threading.Thread.is_alive instead of isAlive

### DIFF
--- a/coapthon/client/coap.py
+++ b/coapthon/client/coap.py
@@ -178,7 +178,7 @@ class CoAP(object):
                 if opt.value == 26:
                     return
 
-        if self._receiver_thread is None or not self._receiver_thread.isAlive():
+        if self._receiver_thread is None or not self._receiver_thread.is_alive():
             self._receiver_thread = threading.Thread(target=self.receive_datagram)
             self._receiver_thread.daemon = True
             self._receiver_thread.start()


### PR DESCRIPTION
The method threading.Thread.isAlive has been removed in Python 3. See [Python's threading docs](https://docs.python.org/3/library/threading.html#threading.Thread.is_alive).