### PR TITLE
Add missing decorator @property to size1 method in Message class

### DIFF
--- a/coapthon/messages/message.py
+++ b/coapthon/messages/message.py
@@ -646,6 +646,7 @@ class Message(object):
         """
         self.del_option_by_number(defines.OptionRegistry.BLOCK2.number)
         
+    @property
     def size1(self):
         value = None
         for option in self.options:


### PR DESCRIPTION
It looks during merging of pull requests and resolving conflicts one decorator was lost