### PR TITLE
Replace all isSet function calls with is_set

### DIFF
--- a/coapthon/client/coap.py
+++ b/coapthon/client/coap.py
@@ -215,9 +215,9 @@ class CoAP(object):
             logger.debug("retransmit loop ... enter")
             while retransmit_count <= defines.MAX_RETRANSMIT \
                     and (not message.acknowledged and not message.rejected) \
-                    and not transaction.retransmit_stop.isSet():
+                    and not transaction.retransmit_stop.is_set():
                 transaction.retransmit_stop.wait(timeout=future_time)
-                if not message.acknowledged and not message.rejected and not transaction.retransmit_stop.isSet():
+                if not message.acknowledged and not message.rejected and not transaction.retransmit_stop.is_set():
                     retransmit_count += 1
                     future_time *= 2
                     if retransmit_count < defines.MAX_RETRANSMIT:
@@ -247,7 +247,7 @@ class CoAP(object):
         Receive datagram from the UDP socket and invoke the callback function.
         """
         logger.debug("Start receiver Thread")
-        while not self.stopped.isSet():
+        while not self.stopped.is_set():
             self._socket.settimeout(0.1)
             try:
                 datagram, addr = self._socket.recvfrom(1500)

--- a/coapthon/client/helperclient.py
+++ b/coapthon/client/helperclient.py
@@ -59,7 +59,7 @@ class HelperClient(object):
         :param callback: the callback function
         """
         self.protocol.send_message(request)
-        while not self.protocol.stopped.isSet():
+        while not self.protocol.stopped.is_set():
             response = self.queue.get(block=True)
             callback(response)
 

--- a/coapthon/forward_proxy/coap.py
+++ b/coapthon/forward_proxy/coap.py
@@ -120,7 +120,7 @@ class CoAP(object):
         """
         Clean old transactions
         """
-        while not self.stopped.isSet():
+        while not self.stopped.is_set():
             self.stopped.wait(timeout=defines.EXCHANGE_LIFETIME)
             self._messageLayer.purge()
 
@@ -131,7 +131,7 @@ class CoAP(object):
         :param timeout: Socket Timeout in seconds
         """
         self._socket.settimeout(float(timeout))
-        while not self.stopped.isSet():
+        while not self.stopped.is_set():
             try:
                 data, client_address = self._socket.recvfrom(4096)
             except socket.timeout:
@@ -264,7 +264,7 @@ class CoAP(object):
         :type message: Message
         :param message: the message to send
         """
-        if not self.stopped.isSet():
+        if not self.stopped.is_set():
             host, port = message.destination
             logger.info("send_datagram - " + str(message))
             serializer = Serializer()
@@ -302,9 +302,9 @@ class CoAP(object):
         """
         with transaction:
             while retransmit_count < defines.MAX_RETRANSMIT and (not message.acknowledged and not message.rejected) \
-                    and not self.stopped.isSet():
+                    and not self.stopped.is_set():
                 transaction.retransmit_stop.wait(timeout=future_time)
-                if not message.acknowledged and not message.rejected and not self.stopped.isSet():
+                if not message.acknowledged and not message.rejected and not self.stopped.is_set():
                     retransmit_count += 1
                     future_time *= 2
                     self.send_datagram(message)

--- a/coapthon/reverse_proxy/coap.py
+++ b/coapthon/reverse_proxy/coap.py
@@ -220,7 +220,7 @@ class CoAP(object):
         """
         Clean old transactions
         """
-        while not self.stopped.isSet():
+        while not self.stopped.is_set():
             self.stopped.wait(timeout=defines.EXCHANGE_LIFETIME)
             self._messageLayer.purge()
 
@@ -231,7 +231,7 @@ class CoAP(object):
         :param timeout: Socket Timeout in seconds
         """
         self._socket.settimeout(float(timeout))
-        while not self.stopped.isSet():
+        while not self.stopped.is_set():
             try:
                 data, client_address = self._socket.recvfrom(4096)
             except socket.timeout:
@@ -353,7 +353,7 @@ class CoAP(object):
         :type message: Message
         :param message: the message to send
         """
-        if not self.stopped.isSet():
+        if not self.stopped.is_set():
             host, port = message.destination
             logger.info("send_datagram - " + str(message))
             serializer = Serializer()
@@ -418,9 +418,9 @@ class CoAP(object):
         """
         with transaction:
             while retransmit_count < defines.MAX_RETRANSMIT and (not message.acknowledged and not message.rejected) \
-                    and not self.stopped.isSet():
+                    and not self.stopped.is_set():
                 transaction.retransmit_stop.wait(timeout=future_time)
-                if not message.acknowledged and not message.rejected and not self.stopped.isSet():
+                if not message.acknowledged and not message.rejected and not self.stopped.is_set():
                     retransmit_count += 1
                     future_time *= 2
                     self.send_datagram(message)

--- a/coapthon/server/coap.py
+++ b/coapthon/server/coap.py
@@ -113,7 +113,7 @@ class CoAP(object):
         Clean old transactions
 
         """
-        while not self.stopped.isSet():
+        while not self.stopped.is_set():
             self.stopped.wait(timeout=defines.EXCHANGE_LIFETIME)
             self._messageLayer.purge()
 
@@ -124,7 +124,7 @@ class CoAP(object):
         :param timeout: Socket Timeout in seconds
         """
         self._socket.settimeout(float(timeout))
-        while not self.stopped.isSet():
+        while not self.stopped.is_set():
             try:
                 data, client_address = self._socket.recvfrom(4096)
                 if len(client_address) > 2:
@@ -240,7 +240,7 @@ class CoAP(object):
         :type message: Message
         :param message: the message to send
         """
-        if not self.stopped.isSet():
+        if not self.stopped.is_set():
             host, port = message.destination
             logger.info("send_datagram - " + str(message))
             serializer = Serializer()
@@ -325,10 +325,10 @@ class CoAP(object):
         """
         with transaction:
             while retransmit_count < defines.MAX_RETRANSMIT and (not message.acknowledged and not message.rejected) \
-                    and not self.stopped.isSet():
+                    and not self.stopped.is_set():
                 if transaction.retransmit_stop is not None:
                     transaction.retransmit_stop.wait(timeout=future_time)
-                if not message.acknowledged and not message.rejected and not self.stopped.isSet():
+                if not message.acknowledged and not message.rejected and not self.stopped.is_set():
                     retransmit_count += 1
                     future_time *= 2
                     self.send_datagram(message)


### PR DESCRIPTION
The new is_set() snake-case spelling has been available since
Python 2.6:
https://docs.python.org/2/library/threading.html#threading.Event.is_set

The old isSet() camel-case spelling raises a deprecation warning with
Python 3.10:
https://docs.python.org/3.10/whatsnew/3.10.html#deprecated
